### PR TITLE
Fix start menu closing tags

### DIFF
--- a/index.html
+++ b/index.html
@@ -640,4 +640,9 @@ Response Time: Within 24 hours
             <div class="start-menu-item programs" data-window="my-computer">My Computer</div>
             <div class="start-menu-item documents" data-window="about-me">About Me</div>
             <div class="start-menu-item documents" data-window="experience">Experience</div>
-            <div class="start-menu-item documents" data-window="skills">Skills</div
+            <div class="start-menu-item documents" data-window="skills">Skills</div>
+        </div>
+    </div>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary
- close dangling start menu item container in index.html
- add missing closing tags for start menu, body, and html elements

## Testing
- `curl -s -H 'Content-Type: text/html; charset=utf-8' --data-binary @index.html https://validator.w3.org/nu/?out=json | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68b3811ac18c8320a8aac1b63c525791