### PR TITLE
Enable desktop icons to open windows

### DIFF
--- a/index.html
+++ b/index.html
@@ -644,5 +644,34 @@ Response Time: Within 24 hours
         </div>
     </div>
 
+    <script>
+    document.addEventListener('DOMContentLoaded', function () {
+        const icons = document.querySelectorAll('.desktop-icon');
+        const windows = document.querySelectorAll('.window');
+        let topZ = 100;
+
+        function bringToFront(win) {
+            windows.forEach(w => w.classList.remove('active'));
+            topZ++;
+            win.classList.add('active');
+            win.style.zIndex = topZ;
+        }
+
+        icons.forEach(icon => {
+            icon.addEventListener('dblclick', function () {
+                const win = document.getElementById(icon.dataset.window);
+                if (win) {
+                    win.classList.remove('hidden');
+                    bringToFront(win);
+                }
+            });
+        });
+
+        windows.forEach(win => {
+            win.addEventListener('mousedown', () => bringToFront(win));
+        });
+    });
+    </script>
+
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add DOMContentLoaded script to wire desktop icons to windows
- ensure double-click reveals window via data attribute
- raise opened window to the front

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b386e785f48320aa42c346d9cc26a2